### PR TITLE
No need to check shouldAuthenticate in the AppDelegate

### DIFF
--- a/shared/hybrid/AppDelegate+SalesforceHybridSDK.m
+++ b/shared/hybrid/AppDelegate+SalesforceHybridSDK.m
@@ -93,13 +93,9 @@
     [self initializeAppViewState];
      __weak __typeof (self) weakSelf = self;
 
-    if (SalesforceHybridSDKManager.sharedManager.appConfig.shouldAuthenticate) {
-        [SFSDKAuthHelper loginIfRequired:^{
-            [weakSelf setupRootViewController];
-        }];
-    } else {
-        [self setupRootViewController];
-    }
+    [SFSDKAuthHelper loginIfRequired:^{
+        [weakSelf setupRootViewController];
+    }];
 
     return YES; // we don't want to run's Cordova didFinishLaunchingWithOptions - it creates another window with a webview
                 // if devs want to customize their AppDelegate.m, then they should get rid of AppDelegate+SalesforceHybrid.m


### PR DESCRIPTION
That check will now take place in SFSDKAuthHelper's loginIfRequired (see https://github.com/forcedotcom/SalesforceMobileSDK-iOS/pull/2756)