### PR TITLE
 Disabling dev support in release builds in hybrid apps

### DIFF
--- a/shared/hybrid/AppDelegate+SalesforceHybridSDK.m
+++ b/shared/hybrid/AppDelegate+SalesforceHybridSDK.m
@@ -52,6 +52,13 @@
     // Need to use SalesforceHybridSDKManager in hybrid apps
     [SalesforceHybridSDKManager initializeSDK];
     
+#ifdef DEBUG
+    [SalesforceHybridSDKManager sharedManager].isDevSupportEnabled = YES;
+#else
+    [SalesforceHybridSDKManager sharedManager].isDevSupportEnabled = NO;
+#endif
+
+    
     //App Setup for any changes to the current authenticated user
     __weak __typeof (self) weakSelf = self;
     [SFSDKAuthHelper registerBlockForCurrentUserChangeNotifications:^{


### PR DESCRIPTION
Hybrid apps consume the Mobile SDK as compiled libraries and as a result the dev support is always on unless you disable it from the AppDelegate.