### PR TITLE
Enhancing session timeout rehydration in custom login URL scenarios

### DIFF
--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
@@ -498,6 +498,10 @@ static NSString * const kSFAppFeatureUsesUIWebView = @"WV";
 
 - (BOOL)isSamlLoginRedirect:(NSString *)url {
     if (self.authConfig) {
+        NSString *loginPageUrl = self.authConfig.loginPageUrl;
+        if (loginPageUrl && [url containsString:loginPageUrl]) {
+            return YES;
+        }
         NSArray<NSString *> *ssoUrls = self.authConfig.ssoUrls;
         if (ssoUrls && ssoUrls.count > 0) {
             for (NSString *ssoUrl in ssoUrls) {


### PR DESCRIPTION
In some scenarios such as communities, customers can configure custom login URLs and strip all parameters on the URL without `MyDomain` configured. This would drop `ec=302` in those cases. This PR closes that gap. Equivalent of [this PR](https://github.com/forcedotcom/SalesforceMobileSDK-Android/pull/1854) on `Android`.