### PR TITLE
Upgrading to CocoaLumberjack 3.5.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/apache/cordova-plugin-wkwebview-engine
 [submodule "external/CocoaLumberjack"]
 	path = external/CocoaLumberjack
-	url = https://github.com/forcedotcom/CocoaLumberjack
+	url = https://github.com/CocoaLumberjack/CocoaLumberjack
 [submodule "external/SalesforceMobileSDK-iOS"]
 	path = external/SalesforceMobileSDK-iOS
 	url = https://github.com/forcedotcom/SalesforceMobileSDK-iOS

--- a/SalesforceFileLogger.podspec
+++ b/SalesforceFileLogger.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'SalesforceFileLogger' do |filelogger|
       filelogger.dependency 'SalesforceSDKCommon'
-      filelogger.dependency 'CocoaLumberjack', '~> 2.4.0'
+      filelogger.dependency 'CocoaLumberjack', '~> 3.5.1'
       filelogger.source_files = 'libs/SalesforceFileLogger/SalesforceFileLogger/Classes/**/*.{h,m}', 'libs/SalesforceFileLogger/SalesforceFileLogger/SalesforceFileLogger.h'
       filelogger.public_header_files = 'libs/SalesforceFileLogger/SalesforceFileLogger/Classes/Logger/SFSDKFileLogger.h', 'libs/SalesforceFileLogger/SalesforceFileLogger/Classes/Logger/SFSDKLogFileManager.h', 'libs/SalesforceFileLogger/SalesforceFileLogger/Classes/Logger/SFSDKLogger.h', 'libs/SalesforceFileLogger/SalesforceFileLogger/SalesforceFileLogger.h'
       filelogger.prefix_header_contents = ''

--- a/libs/SalesforceFileLogger/SalesforceFileLogger/Classes/Logger/SFSDKLogger.m
+++ b/libs/SalesforceFileLogger/SalesforceFileLogger/Classes/Logger/SFSDKLogger.m
@@ -207,7 +207,7 @@ static NSMutableDictionary<NSString *, SFSDKLogger *> *loggerList = nil;
 
 - (void)logInternal:(Class)cls level:(DDLogLevel)level message:(NSString *)message  {
     NSString *tag = [NSString stringWithFormat:kLogIdentifierFormat, self.componentName, cls];
-    DDLogMessage *logMessage = [[DDLogMessage alloc] initWithMessage:message level:level flag:DDLogFlagForLogLevel(level) context:0 file:nil function:nil line:0 tag:tag options:0 timestamp:[NSDate date]];
+    DDLogMessage *logMessage = [[DDLogMessage alloc] initWithMessage:message level:level flag:DDLogFlagForLogLevel(level) context:0 file:self.componentName function:nil line:0 tag:tag options:0 timestamp:[NSDate date]];
     [self.logger log:YES message:logMessage];
 }
 

--- a/libs/SalesforceFileLogger/SalesforceFileLoggerTests/SFSDKLoggerTests.m
+++ b/libs/SalesforceFileLogger/SalesforceFileLoggerTests/SFSDKLoggerTests.m
@@ -78,7 +78,7 @@ unsigned long long const kDefaultMaxFileSize = 1024 * 1024; // 1 MB.
 - (void)testFlushLogFile {
     SFSDKLogger *logger = [SFSDKLogger sharedInstanceWithComponent:kTestComponent1];
     XCTAssertEqualObjects(nil, [logger.fileLogger readFile], @"Log file should be empty");
-    [logger.logger log:NO message:[self messageForLogLine:kTestLogLine1]];
+    [logger.logger log:NO message:[self messageForLogLine:kTestLogLine1 logger:logger]];
     XCTAssertNotEqualObjects(nil, [logger.fileLogger readFile], @"Log file should not be empty");
     [logger.fileLogger flushLogWithCompletionBlock:nil];
     
@@ -93,7 +93,7 @@ unsigned long long const kDefaultMaxFileSize = 1024 * 1024; // 1 MB.
 - (void)testAddLogLine {
     SFSDKLogger *logger = [SFSDKLogger sharedInstanceWithComponent:kTestComponent1];
     XCTAssertEqualObjects(nil, [logger.fileLogger readFile], @"Log file should be empty");
-    [logger.logger log:NO message:[self messageForLogLine:kTestLogLine1]];
+    [logger.logger log:NO message:[self messageForLogLine:kTestLogLine1 logger:logger]];
     XCTAssertNotEqualObjects(nil, [logger.fileLogger readFile], @"Log file should not be empty");
     XCTAssertTrue([[logger.fileLogger readFile] containsString:kTestLogLine1], @"Log file doesn't contain expected log line");
 }
@@ -104,9 +104,9 @@ unsigned long long const kDefaultMaxFileSize = 1024 * 1024; // 1 MB.
 - (void) testAddMultipleLogLines {
     SFSDKLogger *logger = [SFSDKLogger sharedInstanceWithComponent:kTestComponent1];
     XCTAssertEqualObjects(nil, [logger.fileLogger readFile], @"Log file should be empty");
-    [logger.logger log:NO message:[self messageForLogLine:kTestLogLine1]];
-    [logger.logger log:NO message:[self messageForLogLine:kTestLogLine2]];
-    [logger.logger log:NO message:[self messageForLogLine:kTestLogLine3]];
+    [logger.logger log:NO message:[self messageForLogLine:kTestLogLine1 logger:logger]];
+    [logger.logger log:NO message:[self messageForLogLine:kTestLogLine2 logger:logger]];
+    [logger.logger log:NO message:[self messageForLogLine:kTestLogLine3 logger:logger]];
     XCTAssertNotEqualObjects(nil, [logger.fileLogger readFile], @"Log file should not be empty");
     XCTAssertTrue([[logger.fileLogger readFile] containsString:kTestLogLine1], @"Log file doesn't contain expected log line");
     XCTAssertTrue([[logger.fileLogger readFile] containsString:kTestLogLine2], @"Log file doesn't contain expected log line");
@@ -118,7 +118,7 @@ unsigned long long const kDefaultMaxFileSize = 1024 * 1024; // 1 MB.
     SFSDKLogger *logger = [SFSDKLogger sharedInstanceWithComponent:kTestComponent1];
     SFSDKFileLogger *origFileLogger = logger.fileLogger;
     XCTAssertNil([logger.fileLogger readFile], @"Log file should be empty");
-    [logger.logger log:NO message:[self messageForLogLine:kTestLogLine1]];
+    [logger.logger log:NO message:[self messageForLogLine:kTestLogLine1 logger:logger]];
     XCTAssertNotNil([logger.fileLogger readFile], @"Log file should not be empty");
     XCTAssertTrue([[logger.fileLogger readFile] containsString:kTestLogLine1], @"Log file doesn't contain expected log line");
     
@@ -127,7 +127,7 @@ unsigned long long const kDefaultMaxFileSize = 1024 * 1024; // 1 MB.
     logger.fileLogger = newFileLogger;
     XCTAssertNotEqual(logger.fileLogger, origFileLogger, @"File logger should have changed to the new file logger.");
     XCTAssertNil([logger.fileLogger readFile], @"Log file should be empty");
-    [logger.logger log:NO message:[self messageForLogLine:kTestLogLine2]];
+    [logger.logger log:NO message:[self messageForLogLine:kTestLogLine2 logger:logger]];
     XCTAssertNotNil([logger.fileLogger readFile], @"Log file should not be empty");
     XCTAssertTrue([[logger.fileLogger readFile] containsString:kTestLogLine2], @"New log file doesn't contain expected log line");
     XCTAssertFalse([[logger.fileLogger readFile] containsString:kTestLogLine1], @"New log file contains unexpected log line");
@@ -152,9 +152,9 @@ unsigned long long const kDefaultMaxFileSize = 1024 * 1024; // 1 MB.
     logger2.fileLogger = logger1.fileLogger;
     XCTAssertEqual(logger1.fileLogger, logger2.fileLogger, @"File logger should be the same for both components.");
     XCTAssertNil([logger1.fileLogger readFile], @"Log file should be empty");
-    [logger1.logger log:NO message:[self messageForLogLine:kTestLogLine1]];
-    [logger2.logger log:NO message:[self messageForLogLine:kTestLogLine2]];
-    [logger1.logger log:NO message:[self messageForLogLine:kTestLogLine3]];
+    [logger1.logger log:NO message:[self messageForLogLine:kTestLogLine1 logger:logger1]];
+    [logger2.logger log:NO message:[self messageForLogLine:kTestLogLine2 logger:logger2]];
+    [logger1.logger log:NO message:[self messageForLogLine:kTestLogLine3 logger:logger1]];
     for (SFSDKFileLogger *fileLogger in @[ logger1.fileLogger, logger2.fileLogger ]) {
         XCTAssertNotNil([fileLogger readFile], @"Log file should not be empty");
         XCTAssertTrue([[fileLogger readFile] containsString:kTestLogLine1], @"Log file doesn't contain expected log line");
@@ -169,13 +169,13 @@ unsigned long long const kDefaultMaxFileSize = 1024 * 1024; // 1 MB.
 - (void)testWriteAfterMaxSizeReached {
     SFSDKLogger *logger = [SFSDKLogger sharedInstanceWithComponent:kTestComponent1];
     XCTAssertEqualObjects(nil, [logger.fileLogger readFile], @"Log file should be empty");
-    [logger.logger log:NO message:[self messageForLogLine:kTestLogLine1]];
-    [logger.logger log:NO message:[self messageForLogLine:kTestLogLine2]];
-    [logger.logger log:NO message:[self messageForLogLine:kTestLogLine3]];
+    [logger.logger log:NO message:[self messageForLogLine:kTestLogLine1 logger:logger]];
+    [logger.logger log:NO message:[self messageForLogLine:kTestLogLine2 logger:logger]];
+    [logger.logger log:NO message:[self messageForLogLine:kTestLogLine3 logger:logger]];
     XCTAssertNotEqualObjects(nil, [logger.fileLogger readFile], @"Log file should not be empty");
     logger.fileLogger.maximumFileSize = 1;
     XCTAssertEqual(1, logger.fileLogger.maximumFileSize, @"Max size didn't match expected max size");
-    [logger.logger log:NO message:[self messageForLogLine:kTestLogLine4]];
+    [logger.logger log:NO message:[self messageForLogLine:kTestLogLine4 logger:logger]];
     XCTAssertTrue([[logger.fileLogger readFile] containsString:kTestLogLine4], @"Log file doesn't contain expected log line");
     XCTAssertFalse([[logger.fileLogger readFile] containsString:kTestLogLine1], @"Log file contains unexpected log line");
 }
@@ -268,8 +268,8 @@ unsigned long long const kDefaultMaxFileSize = 1024 * 1024; // 1 MB.
     XCTAssertTrue([logger isFileLoggingEnabled], @"File logger should be enabled");
 }
 
-- (DDLogMessage *)messageForLogLine:(NSString *)logLine {
-    return [[DDLogMessage alloc] initWithMessage:logLine level:DDLogLevelError flag:DDLogFlagError context:0 file:nil function:nil line:0 tag:[self class] options:0 timestamp:[NSDate date]];
+- (DDLogMessage *)messageForLogLine:(NSString *)logLine logger:(SFSDKLogger *)logger {
+    return [[DDLogMessage alloc] initWithMessage:logLine level:DDLogLevelError flag:DDLogFlagError context:0 file:logger.componentName function:nil line:0 tag:[self class] options:0 timestamp:[NSDate date]];
 }
 
 @end


### PR DESCRIPTION
Switching to upstream `CocoaLumberjack` repo and upgrading to `3.5.1` (latest tagged release).