### PR TITLE
Fixing bug with redirect URLs in hybrid view controller for hybrid remote apps

### DIFF
--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
@@ -458,13 +458,13 @@ static NSString * const kSFAppFeatureUsesUIWebView = @"WV";
      */
     if (createAbsUrl && ![returnUrlString hasPrefix:@"http"]) {
         NSURLComponents *retUrlComponents = [NSURLComponents componentsWithURL:instUrl resolvingAgainstBaseURL:NO];
-        retUrlComponents.path = [retUrlComponents.path stringByAppendingPathComponent:returnUrlString];
+        retUrlComponents.path = [retUrlComponents.path stringByAppendingString:returnUrlString];
         fullReturnUrlString = retUrlComponents.string;
     }
 
     // Create frontDoor path based on credentials API URL.
     NSURLComponents *frontDoorUrlComponents = [NSURLComponents componentsWithURL:instUrl resolvingAgainstBaseURL:NO];
-    frontDoorUrlComponents.path = [frontDoorUrlComponents.path stringByAppendingPathComponent:@"/secur/frontdoor.jsp"];
+    frontDoorUrlComponents.path = [frontDoorUrlComponents.path stringByAppendingString:@"/secur/frontdoor.jsp"];
 
     // NB: We're not using NSURLComponents.queryItems here, because it unsufficiently encodes query params.
     NSMutableString *frontDoorUrlString = [NSMutableString stringWithString:frontDoorUrlComponents.string];


### PR DESCRIPTION
The issue is that we're using `stringByAppendingPathComponent` in some situations to construct the URL instead of using `stringByAppendingString`. This leads to dropping parts of the appended string URL - in our case, the trailing `/` is dropped, which causes an extra redirect and higher load time.

From official documentation of `stringByAppendingPathComponent` [here](https://developer.apple.com/documentation/foundation/nsstring/1417069-stringbyappendingpathcomponent?language=objc):
```
Note that this method only works with file paths (not, for example, string representations of URLs).
```