### PR TITLE
Moving to latest cocoalumberjack (3.5.3)

### DIFF
--- a/SalesforceFileLogger.podspec
+++ b/SalesforceFileLogger.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'SalesforceFileLogger' do |filelogger|
       filelogger.dependency 'SalesforceSDKCommon'
-      filelogger.dependency 'CocoaLumberjack', '~> 3.5.1'
+      filelogger.dependency 'CocoaLumberjack', '~> 3.5.3'
       filelogger.source_files = 'libs/SalesforceFileLogger/SalesforceFileLogger/Classes/**/*.{h,m}', 'libs/SalesforceFileLogger/SalesforceFileLogger/SalesforceFileLogger.h'
       filelogger.public_header_files = 'libs/SalesforceFileLogger/SalesforceFileLogger/Classes/Logger/SFSDKFileLogger.h', 'libs/SalesforceFileLogger/SalesforceFileLogger/Classes/Logger/SFSDKLogFileManager.h', 'libs/SalesforceFileLogger/SalesforceFileLogger/Classes/Logger/SFSDKLogger.h', 'libs/SalesforceFileLogger/SalesforceFileLogger/SalesforceFileLogger.h'
       filelogger.prefix_header_contents = ''


### PR DESCRIPTION
Previously, we were on 3.5.1, but that had a bug with file rolling causing one test (testWriteAfterMaxSizeReached) to fail.
The rolling bug was fixed in 3.5.2 (see https://github.com/CocoaLumberjack/CocoaLumberjack/pull/1042).
With 3.5.3, all the SalesforceFileLogger tests are passing.