### PR TITLE
Include communityId and communityUrl in authentication credentials 

### DIFF
--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.h
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.h
@@ -49,6 +49,8 @@ extern NSString * const kOrgIdCredentialsDictKey;
 extern NSString * const kLoginUrlCredentialsDictKey;
 extern NSString * const kInstanceUrlCredentialsDictKey;
 extern NSString * const kUserAgentCredentialsDictKey;
+extern NSString * const kCommunityIdCredentialsDictKey;
+extern NSString * const kCommunityUrlCredentialsDictKey;
 
 /**
  Callback block definition for OAuth plugin auth success.

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
@@ -53,6 +53,8 @@ NSString * const kOrgIdCredentialsDictKey = @"orgId";
 NSString * const kLoginUrlCredentialsDictKey = @"loginUrl";
 NSString * const kInstanceUrlCredentialsDictKey = @"instanceUrl";
 NSString * const kUserAgentCredentialsDictKey = @"userAgent";
+NSString * const kCommunityIdCredentialsDictKey= @"communityId";
+NSString * const kCommunityUrlCredentialsDictKey= @"communityUrl";
 
 // Error page constants.
 static NSString * const kErrorCodeParameterName = @"errorCode";
@@ -364,12 +366,15 @@ static NSString * const kVFPingPageUrl = @"/apexpages/utils/ping.apexp";
     if (nil != creds) {
         NSString *instanceUrl = creds.instanceUrl.absoluteString;
         NSString *loginUrl = [NSString stringWithFormat:@"%@://%@", creds.protocol, creds.domain];
+        NSString *communityUrl = creds.communityUrl ? creds.communityUrl.absoluteString : nil;
         NSString *uaString = [self sfHybridViewUserAgentString];
         credentialsDict = @{kAccessTokenCredentialsDictKey: creds.accessToken,
                            kRefreshTokenCredentialsDictKey: creds.refreshToken,
                            kClientIdCredentialsDictKey: creds.clientId,
                            kUserIdCredentialsDictKey: creds.userId,
                            kOrgIdCredentialsDictKey: creds.organizationId,
+                           kCommunityIdCredentialsDictKey: creds.communityId ?: [NSNull null],
+                           kCommunityUrlCredentialsDictKey: communityUrl ?: [NSNull null],
                            kLoginUrlCredentialsDictKey: loginUrl,
                            kInstanceUrlCredentialsDictKey: instanceUrl,
                            kUserAgentCredentialsDictKey: uaString};


### PR DESCRIPTION
The same change was already done for the react native plugin (see https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative/pull/158)