### PR TITLE
Front door url calculation did not work if return url had no leading slash

### DIFF
--- a/.circleci/fastlane/Fastfile
+++ b/.circleci/fastlane/Fastfile
@@ -5,17 +5,19 @@ ENV['IOS_VERSION'] = '13.0' unless ENV.has_key?('IOS_VERSION')
 
 lane :build do |options|
   scheme = options[:lib]
+  Dir.chdir('../')
   analyze_scheme(scheme)
 end
 
 lane :test do |options|
   scheme = options[:lib]
+  Dir.chdir('../')
   test_scheme(scheme)
 end
 
 def test_scheme(scheme)
   scan(
-    workspace: '../SalesforceMobileSDK-Hybrid.xcworkspace',
+    workspace: 'SalesforceMobileSDK-Hybrid.xcworkspace',
     scheme: scheme,
     device: ENV['DEVICE'] + ' (' + ENV['IOS_VERSION'] + ')',
     output_directory: 'test_output',
@@ -29,7 +31,7 @@ def analyze_scheme(scheme)
   begin
     xcodebuild(
       xcargs: 'CLANG_ANALYZER_OUTPUT=plist-html CLANG_ANALYZER_OUTPUT_DIR=./clangReport RUN_CLANG_STATIC_ANALYZER=YES',
-      workspace: '../SalesforceMobileSDK-Hybrid.xcworkspace',
+      workspace: 'SalesforceMobileSDK-Hybrid.xcworkspace',
       scheme: scheme,
       sdk: 'iphonesimulator',
     )

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK.xcodeproj/project.pbxproj
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		4F458AEF1911CF4C00545F86 /* cordova.force.js in Copy sfdc libs */ = {isa = PBXBuildFile; fileRef = 4F1A59F1174FF0B100473EE8 /* cordova.force.js */; };
 		4F5B966A1DAD9D2B001627F2 /* com.salesforce.plugin.smartstore.client.js in Copy Salesforce plugin */ = {isa = PBXBuildFile; fileRef = 4F5B96661DAD9D09001627F2 /* com.salesforce.plugin.smartstore.client.js */; };
 		4F5B966B1DAD9D2B001627F2 /* com.salesforce.util.promiser.js in Copy Salesforce plugin */ = {isa = PBXBuildFile; fileRef = 4F5B96671DAD9D09001627F2 /* com.salesforce.util.promiser.js */; };
+		4F924C5D24BD4BA700D2F6DC /* SFHybridViewControllerTestSuite.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F924C5C24BD4BA700D2F6DC /* SFHybridViewControllerTestSuite.m */; };
 		4FAA891D1750263200807E13 /* index.html in Copy files to www/ */ = {isa = PBXBuildFile; fileRef = 4FAA891B175025DF00807E13 /* index.html */; };
 		4FC404A91911C6CA0027AD76 /* qunit.css in Copy qunit lib */ = {isa = PBXBuildFile; fileRef = 4FC4049B1911C6720027AD76 /* qunit.css */; };
 		4FC404AA1911C6CA0027AD76 /* qunit.js in Copy qunit lib */ = {isa = PBXBuildFile; fileRef = 4FC4049C1911C6720027AD76 /* qunit.js */; };
@@ -466,6 +467,7 @@
 		4F37EB101DA3246B0049992D /* SFForceJSTestSuite.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = SFForceJSTestSuite.js; sourceTree = "<group>"; };
 		4F5B96661DAD9D09001627F2 /* com.salesforce.plugin.smartstore.client.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = com.salesforce.plugin.smartstore.client.js; sourceTree = "<group>"; };
 		4F5B96671DAD9D09001627F2 /* com.salesforce.util.promiser.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = com.salesforce.util.promiser.js; sourceTree = "<group>"; };
+		4F924C5C24BD4BA700D2F6DC /* SFHybridViewControllerTestSuite.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SFHybridViewControllerTestSuite.m; sourceTree = "<group>"; };
 		4FA19A571992C2B400FA3D69 /* SFLocalhostSubstitutionCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFLocalhostSubstitutionCache.h; sourceTree = "<group>"; };
 		4FA19A581992C2B400FA3D69 /* SFLocalhostSubstitutionCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFLocalhostSubstitutionCache.m; sourceTree = "<group>"; };
 		4FAA891B175025DF00807E13 /* index.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = index.html; path = ../../../external/shared/test/forcepluginstest/index.html; sourceTree = "<group>"; };
@@ -753,6 +755,7 @@
 				4F06AFA61C49A77200F70798 /* ForceJSTestSuite.m */,
 				4F06AFA81C49A77200F70798 /* SDKInfoTestSuite.m */,
 				82AB22641F9EB9C100A754C8 /* SFHybridViewConfigTestSuite.m */,
+				4F924C5C24BD4BA700D2F6DC /* SFHybridViewControllerTestSuite.m */,
 				4F06AFA91C49A77200F70798 /* SFPluginTestSuite.h */,
 				4F06AFAA1C49A77200F70798 /* SFPluginTestSuite.m */,
 				4F06AFAC1C49A77200F70798 /* SmartStoreLoadTestSuite.m */,
@@ -1534,6 +1537,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4F06AFC11C49A7BF00F70798 /* SmartStoreTestSuite.m in Sources */,
+				4F924C5D24BD4BA700D2F6DC /* SFHybridViewControllerTestSuite.m in Sources */,
 				4F06AFBD1C49A7BF00F70798 /* ForceJSTestSuite.m in Sources */,
 				4F06AFC21C49A7BF00F70798 /* MobileSyncTestSuite.m in Sources */,
 				82AB22651F9EB9C100A754C8 /* SFHybridViewConfigTestSuite.m in Sources */,

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
@@ -412,7 +412,8 @@ static NSString * const kVFPingPageUrl = @"/apexpages/utils/ping.apexp";
      */
     if (createAbsUrl && ![returnUrlString hasPrefix:@"http"]) {
         NSURLComponents *retUrlComponents = [NSURLComponents componentsWithURL:instUrl resolvingAgainstBaseURL:NO];
-        retUrlComponents.path = [retUrlComponents.path stringByAppendingString:returnUrlString];
+        NSString* pathToAppend = [returnUrlString hasPrefix:@"/"] ? returnUrlString : [NSString stringWithFormat:@"/%@", returnUrlString];
+        retUrlComponents.path = [retUrlComponents.path stringByAppendingString:pathToAppend];
         fullReturnUrlString = retUrlComponents.string;
     }
 

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDKTests/SFHybridViewControllerTestSuite.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDKTests/SFHybridViewControllerTestSuite.m
@@ -1,0 +1,78 @@
+/*
+ Copyright (c) 2020-present, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <XCTest/XCTest.h>
+#import "SFHybridViewConfig.h"
+#import "SFHybridViewController.h"
+
+@interface SFHybridViewController (tests)
+
+- (NSURL *)frontDoorUrlWithReturnUrl:(NSString *)returnUrlString returnUrlIsEncoded:(BOOL)isEncoded createAbsUrl:(BOOL)createAbsUrl;
+
+@end
+
+@interface SFHybridViewControllerTestSuite : XCTestCase
+
+@property (nonnull, nonatomic, strong) SFHybridViewConfig *hybridViewConfig;
+@property (nonnull, nonatomic, strong) SFHybridViewController *hybridViewController;
+
+@end
+
+@implementation SFHybridViewControllerTestSuite
+
+- (void)setUp {
+    [super setUp];
+    self.hybridViewConfig = [[SFHybridViewConfig alloc] init];
+    self.hybridViewConfig.remoteAccessConsumerKey = @"testConsumerKey";
+    self.hybridViewConfig.oauthRedirectURI = @"test:///redirectUri";
+    self.hybridViewConfig.oauthScopes = [NSSet setWithArray:@[ @"web", @"api" ]];
+    self.hybridViewController = [[SFHybridViewController alloc] initWithConfig:self.hybridViewConfig];
+}
+
+- (void)testFrontDoorUrlNoLeadingSlash {
+    NSURLComponents *components = [NSURLComponents componentsWithURL:[self.hybridViewController frontDoorUrlWithReturnUrl:@"apex/abc" returnUrlIsEncoded:NO createAbsUrl:YES] resolvingAgainstBaseURL:NO];
+    NSString* expectedRetUrl = [NSString stringWithFormat:@"https://%@/apex/abc", components.host];
+    XCTAssertEqualObjects(components.scheme, @"https", "Wrong scheme");
+    XCTAssertEqualObjects(components.path, @"/secur/frontdoor.jsp", "Wrong path");
+    XCTAssertEqualObjects(components.queryItems[0].name, @"sid");
+    XCTAssertEqualObjects(components.queryItems[1].name, @"retURL");
+    XCTAssertEqualObjects(components.queryItems[1].value, expectedRetUrl, "Wrong retUrl");
+    XCTAssertEqualObjects(components.queryItems[2].name, @"display");
+    XCTAssertEqualObjects(components.queryItems[2].value, @"touch");
+}
+
+- (void)testFrontDoorUrlWithLeadingSlash {
+    NSURLComponents *components = [NSURLComponents componentsWithURL:[self.hybridViewController frontDoorUrlWithReturnUrl:@"/apex/abc" returnUrlIsEncoded:NO createAbsUrl:YES] resolvingAgainstBaseURL:NO];
+    NSString* expectedRetUrl = [NSString stringWithFormat:@"https://%@/apex/abc", components.host];
+    XCTAssertEqualObjects(components.scheme, @"https", "Wrong scheme");
+    XCTAssertEqualObjects(components.path, @"/secur/frontdoor.jsp", "Wrong path");
+    XCTAssertEqualObjects(components.queryItems[0].name, @"sid");
+    XCTAssertEqualObjects(components.queryItems[1].name, @"retURL");
+    XCTAssertEqualObjects(components.queryItems[1].value, expectedRetUrl, "Wrong retUrl");
+    XCTAssertEqualObjects(components.queryItems[2].name, @"display");
+    XCTAssertEqualObjects(components.queryItems[2].value, @"touch");
+}
+
+
+@end


### PR DESCRIPTION
Android can handle start page like apex/xyz or /apex/xyz but iOS stopped handling apex/xyz after we changed the method that calculates front door url.

Added tests.