### PR TITLE
Fixing warning

### DIFF
--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.h
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.h
@@ -103,11 +103,6 @@ typedef void (^SFOAuthPluginFailureBlock)(SFOAuthInfo *, NSError *);
 - (id) initWithConfig:(nullable SFHybridViewConfig *) viewConfig;
 
 /**
- * Initializes a new Cordova view with the specified bounds and engine.
- */
-- (UIView *)newCordovaViewWithFrameAndEngine:(CGRect)bounds webViewEngine:(NSString *)webViewEngine;
-
-/**
  Used by the OAuth plugin to authenticate the user.
  @param completionBlock The block to call upon successsful authentication.
  @param failureBlock The block to call in the event of an auth failure.


### PR DESCRIPTION
Removing newCordovaViewWithFrameAndEngine method from header file.
It was removed from .m file with https://github.com/forcedotcom/SalesforceMobileSDK-iOS-Hybrid/pull/155/files#diff-4700cffe458ff98f84362a9c22e991eed9aae180fa93c83e3725ac49ef0fd736