### PR TITLE
Fixing breaking video playback change with Cordova 6.x

### DIFF
--- a/shared/hybrid/config.xml
+++ b/shared/hybrid/config.xml
@@ -45,7 +45,7 @@
     <preference name="DisallowOverscroll" value="false" />
     <preference name="EnableViewportScale" value="false" />
     <preference name="KeyboardDisplayRequiresUserAction" value="true" />
-    <preference name="MediaPlaybackRequiresUserAction" value="false" />
+    <preference name="MediaTypesRequiringUserActionForPlayback" value="none" />
     <preference name="SuppressesIncrementalRendering" value="false" />
     <preference name="TopActivityIndicator" value="gray" />
     <preference name="GapBetweenPages" value="0" />


### PR DESCRIPTION
We discovered this in `CommunitiesApp` due to a customer issue. It's listed as a breaking change in `Cordova 6.x` [here](https://cordova.apache.org/announcements/2020/06/01/cordova-ios-release-6.0.0.html).