### PR TITLE
Fixing bug with refresh failure comparison logic

### DIFF
--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
@@ -501,7 +501,7 @@ static NSString * const kHTTP = @"http";
 
 - (BOOL)logoutOnInvalidCredentials:(NSError *)error
 {
-    if (error.domain == kSFOAuthErrorDomain && error.code == kSFOAuthErrorInvalidGrant) {
+    if ([error.domain isEqualToString:kSFOAuthErrorDomain] && error.code == kSFOAuthErrorInvalidGrant) {
         return YES;
     }
     return NO;


### PR DESCRIPTION
Fixing [this issue](https://github.com/forcedotcom/SalesforceMobileSDK-iOS-Hybrid/issues/162).