### PR TITLE
Fixing URL redirect use case where there  are no query parameters

### DIFF
--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
@@ -446,15 +446,16 @@ static NSString * const kHTTP = @"http";
         return nil;
     }
     if ([url.scheme.lowercaseString hasPrefix:kHTTP]) {
+        NSString *retUrlValue = nil;
         if (url.query != nil) {
-            NSString *retUrlValue = [url valueForParameterName:kRetURLParam];
+            retUrlValue = [url valueForParameterName:kRetURLParam];
             retUrlValue = (retUrlValue == nil) ? [url valueForParameterName:kStartURLParam] : retUrlValue;
-            if (retUrlValue == nil || [retUrlValue containsString:kFrontdoor]) {
-                retUrlValue = self.startPage;
-            }
-            if ([self isSessionExpirationRedirect:url.absoluteString] || [self isSamlLoginRedirect:url.absoluteString] || [self isVFPageRedirect:url]) {
-                return retUrlValue;
-            }
+        }
+        if (retUrlValue == nil || [retUrlValue containsString:kFrontdoor]) {
+            retUrlValue = self.startPage;
+        }
+        if ([self isSessionExpirationRedirect:url.absoluteString] || [self isSamlLoginRedirect:url.absoluteString] || [self isVFPageRedirect:url]) {
+            return retUrlValue;
         }
     }
     return nil;


### PR DESCRIPTION
In some cases, there are no query parameters in the login redirect URL, but pattern matching should still occur to properly load our login view controller. Otherwise, the app will incorrectly be logged in on the hybrid webview, and the app will be in a bad state.