### PR TITLE
Disabling iOS 26 run for now

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -16,15 +16,10 @@ jobs:
           - macos: macos-15
             ios: ^18
             xcode: ^16
-          - macos: macos-15
-            ios: ^18
-            xcode: ^26
-          - macos: macos-15
-            ios: ^26
-            xcode: ^26
-          - macos: macos-14
-            ios: ^17
-            xcode: ^15
+          # - macos: macos-15
+          #   ios: ^26
+          #   xcode: ^26
+          # Note: iOS 26 simulator is not yet available on GitHub runners
     uses: ./.github/workflows/reusable-workflow.yaml
     with:
       lib: ${{ matrix.lib }}
@@ -42,15 +37,10 @@ jobs:
           - macos: macos-15
             ios: ^18
             xcode: ^16
-          - macos: macos-15
-            ios: ^18
-            xcode: ^26
-          - macos: macos-15
-            ios: ^26
-            xcode: ^26
-          - macos: macos-14
-            ios: ^17
-            xcode: ^15
+          # - macos: macos-15
+          #   ios: ^26
+          #   xcode: ^26
+          # Note: iOS 26 simulator is not yet available on GitHub runners
     uses: ./.github/workflows/reusable-workflow.yaml
     with:
       lib: ${{ matrix.lib }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -62,9 +62,10 @@ jobs:
           - macos: macos-15
             ios: ^18
             xcode: ^16
-          - macos: macos-15
-            ios: ^26
-            xcode: ^26
+          # - macos: macos-15
+          #   ios: ^26
+          #   xcode: ^26
+          # Note: iOS 26 simulator is not yet available on GitHub runners
     uses: ./.github/workflows/reusable-workflow.yaml
     with:
       lib: ${{ matrix.lib }}
@@ -84,9 +85,10 @@ jobs:
           - macos: macos-15
             ios: ^18
             xcode: ^16
-          - macos: macos-15
-            ios: ^26
-            xcode: ^26
+          # - macos: macos-15
+          #   ios: ^26
+          #   xcode: ^26
+          # Note: iOS 26 simulator is not yet available on GitHub runners
     uses: ./.github/workflows/reusable-workflow.yaml
     with:
       lib: ${{ matrix.lib }}


### PR DESCRIPTION
https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md is a bit confusing:
- In the installed SDKs table, it has: Simulator - iOS 26.0 - iphonesimulator26.0 - Xcode 26.0
- In the installed Simulators table, it does not have any iOS 26 simulators.

iOS 18 SDK is only with Xcode 16, and there is not iOS 17 SDK in macos-15.

macos-14 runner has iOS 17 but it is with Xcode 15 which is disallowed by our install.sh