### PR TITLE
Leverage Category in OSLog for SFSDKLogger

### DIFF
--- a/libs/SalesforceFileLogger/SalesforceFileLogger/Classes/Logger/SFSDKLogger.h
+++ b/libs/SalesforceFileLogger/SalesforceFileLogger/Classes/Logger/SFSDKLogger.h
@@ -40,9 +40,9 @@
 @property (nonatomic, readonly, strong, nonnull) NSString *componentName;
 
 /**
- * Instance of the underlying console logger being used.
+ * Dictionary of console loggers, keyed by component name.
  */
-@property (nonatomic, readonly, strong, nonnull) DDLog *consoleLogger;
+@property (nonatomic, readonly, strong, nonnull) NSMutableDictionary<NSString *, DDLog *> *consoleLoggers;
 
 /**
  * Instance of the underlying file logger being used.

--- a/libs/SalesforceFileLogger/SalesforceFileLogger/Classes/Logger/SFSDKLogger.h
+++ b/libs/SalesforceFileLogger/SalesforceFileLogger/Classes/Logger/SFSDKLogger.h
@@ -40,9 +40,9 @@
 @property (nonatomic, readonly, strong, nonnull) NSString *componentName;
 
 /**
- * Instance of the underlying logger being used.
+ * Instance of the underlying console logger being used.
  */
-@property (nonatomic, readonly, strong, nonnull) DDLog *logger;
+@property (nonatomic, readonly, strong, nonnull) DDLog *consoleLogger;
 
 /**
  * Instance of the underlying file logger being used.

--- a/libs/SalesforceFileLogger/SalesforceFileLogger/Classes/Logger/SFSDKLogger.m
+++ b/libs/SalesforceFileLogger/SalesforceFileLogger/Classes/Logger/SFSDKLogger.m
@@ -260,7 +260,7 @@ static BOOL _useOSLog = NO;
     // Get or create console logger for this tag
     DDLog *consoleLoggerDDLog = self.consoleLoggers[tag];
     if (!consoleLoggerDDLog) {
-      // Create new console logger for this class
+      // Create new console logger for this tag
       consoleLoggerDDLog = [[DDLog alloc] init];
       id<DDLogger> consoleLogger;
       if ([self.class useOSLog]) {

--- a/libs/SalesforceFileLogger/SalesforceFileLogger/Classes/Logger/SFSDKLogger.m
+++ b/libs/SalesforceFileLogger/SalesforceFileLogger/Classes/Logger/SFSDKLogger.m
@@ -189,17 +189,18 @@ static BOOL _useOSLog = NO;
 - (void)setDdLogLevel:(DDLogLevel)logLevel {
     [self storeLogLevel:logLevel];
 
-    // Update console logger for this component
-    DDLog *consoleLoggerDDLog = self.consoleLoggers[self.componentName];
-    if (consoleLoggerDDLog) {
+    // Update all console loggers
+    for (NSString *className in self.consoleLoggers.allKeys) {
+      DDLog *consoleLoggerDDLog = self.consoleLoggers[className];
       [consoleLoggerDDLog removeAllLoggers];
       id<DDLogger> consoleLogger;
       if ([self.class useOSLog]) {
-        consoleLogger = [[DDOSLogger alloc]
-            initWithSubsystem:[[NSBundle mainBundle] bundleIdentifier]
-            category:self.componentName];
+        consoleLogger =
+            [[DDOSLogger alloc] initWithSubsystem:[[NSBundle mainBundle] bundleIdentifier]
+                                category:className];
       } else {
         DDTTYLogger *ttyLogger = [DDTTYLogger sharedInstance];
+        ttyLogger.logFormatter = [[SFSDKFormatter alloc] init];
         ttyLogger.colorsEnabled = YES;
         consoleLogger = ttyLogger;
       }

--- a/libs/SalesforceFileLogger/SalesforceFileLogger/Classes/Logger/SFSDKLogger.m
+++ b/libs/SalesforceFileLogger/SalesforceFileLogger/Classes/Logger/SFSDKLogger.m
@@ -257,9 +257,8 @@ static BOOL _useOSLog = NO;
     NSString *tag = [NSString stringWithFormat:kLogIdentifierFormat, self.componentName, cls];
     DDLogMessage *logMessage = [[DDLogMessage alloc] initWithFormat:message formatted:message level:level flag:DDLogFlagForLogLevel(level) context:0 file:self.componentName function:nil line:0 tag:tag options:0 timestamp:[NSDate date]];
 
-    // Get or create console logger for this class
-    NSString *className = NSStringFromClass(cls);
-    DDLog *consoleLoggerDDLog = self.consoleLoggers[className];
+    // Get or create console logger for this tag
+    DDLog *consoleLoggerDDLog = self.consoleLoggers[tag];
     if (!consoleLoggerDDLog) {
       // Create new console logger for this class
       consoleLoggerDDLog = [[DDLog alloc] init];
@@ -267,7 +266,7 @@ static BOOL _useOSLog = NO;
       if ([self.class useOSLog]) {
         consoleLogger =
             [[DDOSLogger alloc] initWithSubsystem:[[NSBundle mainBundle] bundleIdentifier]
-                                category:className];
+                                         category:tag];
       } else {
         DDTTYLogger *ttyLogger = [DDTTYLogger sharedInstance];
         ttyLogger.logFormatter = [[SFSDKFormatter alloc] init];
@@ -276,7 +275,7 @@ static BOOL _useOSLog = NO;
       }
       [consoleLoggerDDLog addLogger:consoleLogger
                           withLevel:DDLogLogLevelForSFLogLevel(self.logLevel)];
-      self.consoleLoggers[className] = consoleLoggerDDLog;
+      self.consoleLoggers[tag] = consoleLoggerDDLog;
     }
 
     // Log to console logger for this class

--- a/libs/SalesforceFileLogger/SalesforceFileLogger/Classes/Logger/SFSDKLogger.m
+++ b/libs/SalesforceFileLogger/SalesforceFileLogger/Classes/Logger/SFSDKLogger.m
@@ -42,7 +42,8 @@ static BOOL _useOSLog = NO;
 @interface SFSDKLogger ()
 
 @property (nonatomic, readwrite, strong) NSString *componentName;
-@property (nonatomic, readwrite, strong) DDLog *logger;
+@property(nonatomic, readwrite, strong) DDLog *consoleLogger;
+@property(nonatomic, readwrite, strong) DDLog *fileLoggerDDLog;
 @end
 
 @implementation SFSDKLogger
@@ -102,9 +103,9 @@ static BOOL _useOSLog = NO;
     self = [super init];
     if (self) {
         self.componentName = componentName;
-        self.logger = [[DDLog alloc] init];
-        self.fileLogger = [[SFSDKFileLogger alloc] initWithComponent:componentName];
-        
+
+        // Create separate console logger
+        self.consoleLogger = [[DDLog alloc] init];
         id<DDLogger> consoleLogger;
         if ([self.class useOSLog]) {
             consoleLogger = [[DDOSLogger alloc] initWithSubsystem:[[NSBundle mainBundle] bundleIdentifier] category:componentName];
@@ -114,10 +115,19 @@ static BOOL _useOSLog = NO;
             ttyLogger.colorsEnabled = YES;
             consoleLogger = ttyLogger;
         }
-        
-        [self.logger addLogger:consoleLogger withLevel:DDLogLogLevelForSFLogLevel(self.logLevel)];
+        [self.consoleLogger
+            addLogger:consoleLogger
+            withLevel:DDLogLogLevelForSFLogLevel(self.logLevel)];
+
+        // Create separate file logger
+        self.fileLogger =
+            [[SFSDKFileLogger alloc] initWithComponent:componentName];
+        self.fileLoggerDDLog = [[DDLog alloc] init];
+
         if (self.fileLoggingEnabled) {
-            [self.logger addLogger:self.fileLogger withLevel:DDLogLogLevelForSFLogLevel(self.logLevel)];
+          [self.fileLoggerDDLog
+              addLogger:self.fileLogger
+              withLevel:DDLogLogLevelForSFLogLevel(self.logLevel)];
         }
     }
     return self;
@@ -126,8 +136,10 @@ static BOOL _useOSLog = NO;
 - (void)setFileLogger:(SFSDKFileLogger *)fileLogger {
     if (fileLogger != _fileLogger) {
         if (self.isFileLoggingEnabled) {
-            [_logger removeLogger:_fileLogger];
-            [_logger addLogger:fileLogger withLevel:DDLogLogLevelForSFLogLevel(self.logLevel)];
+          [_fileLoggerDDLog removeLogger:_fileLogger];
+          [_fileLoggerDDLog
+              addLogger:fileLogger
+              withLevel:DDLogLogLevelForSFLogLevel(self.logLevel)];
         }
         _fileLogger = fileLogger;
     }
@@ -141,9 +153,14 @@ static BOOL _useOSLog = NO;
     // Adds or removes the file logger depending on the change in policy.
     if (curPolicy != newPolicy) {
         if (newPolicy) {
-            [self.logger addLogger:self.fileLogger withLevel:DDLogLogLevelForSFLogLevel(self.logLevel)]; // Disabled to enabled.
+          [self.fileLoggerDDLog
+              addLogger:self.fileLogger
+              withLevel:DDLogLogLevelForSFLogLevel(
+                            self.logLevel)]; // Disabled to enabled.
+
         } else {
-            [self.logger removeLogger:self.fileLogger]; // Enabled to disabled.
+          [self.fileLoggerDDLog
+              removeLogger:self.fileLogger]; // Enabled to disabled.
         }
     }
 }
@@ -167,8 +184,9 @@ static BOOL _useOSLog = NO;
 
 - (void)setDdLogLevel:(DDLogLevel)logLevel {
     [self storeLogLevel:logLevel];
-    [self.logger removeAllLoggers];
-    
+
+    // Update console logger
+    [self.consoleLogger removeAllLoggers];
     id<DDLogger> consoleLogger;
     if ([self.class useOSLog]) {
         consoleLogger = [[DDOSLogger alloc] initWithSubsystem:[[NSBundle mainBundle] bundleIdentifier] category:self.componentName];
@@ -177,9 +195,13 @@ static BOOL _useOSLog = NO;
         ttyLogger.colorsEnabled = YES;
         consoleLogger = ttyLogger;
     }
-    
-    [self.logger addLogger:consoleLogger withLevel:logLevel];
-    [self.logger addLogger:self.fileLogger withLevel:logLevel];
+    [self.consoleLogger addLogger:consoleLogger withLevel:logLevel];
+
+    // Update file logger
+    [self.fileLoggerDDLog removeAllLoggers];
+    if (self.fileLoggingEnabled) {
+      [self.fileLoggerDDLog addLogger:self.fileLogger withLevel:logLevel];
+    }
 }
 
 - (void)e:(Class)cls format:(NSString *)format, ... {
@@ -240,7 +262,14 @@ static BOOL _useOSLog = NO;
 - (void)logInternal:(Class)cls level:(DDLogLevel)level message:(NSString *)message  {
     NSString *tag = [NSString stringWithFormat:kLogIdentifierFormat, self.componentName, cls];
     DDLogMessage *logMessage = [[DDLogMessage alloc] initWithFormat:message formatted:message level:level flag:DDLogFlagForLogLevel(level) context:0 file:self.componentName function:nil line:0 tag:tag options:0 timestamp:[NSDate date]];
-    [self.logger log:YES message:logMessage];
+
+    // Log to console logger
+    [self.consoleLogger log:YES message:logMessage];
+
+    // Log to file logger if enabled
+    if (self.fileLoggingEnabled) {
+      [self.fileLoggerDDLog log:YES message:logMessage];
+    }
 }
 
 - (void)logInternal:(Class)cls level:(DDLogLevel)level format:(NSString *)format args:(va_list)args {

--- a/libs/SalesforceFileLogger/SalesforceFileLogger/Classes/Logger/SFSDKLogger.m
+++ b/libs/SalesforceFileLogger/SalesforceFileLogger/Classes/Logger/SFSDKLogger.m
@@ -107,22 +107,6 @@ static BOOL _useOSLog = NO;
         // Create console loggers dictionary
         self.consoleLoggers = [[NSMutableDictionary alloc] init];
 
-        // Create console logger for this component
-        DDLog *consoleLoggerDDLog = [[DDLog alloc] init];
-        id<DDLogger> consoleLogger;
-        if ([self.class useOSLog]) {
-            consoleLogger = [[DDOSLogger alloc] initWithSubsystem:[[NSBundle mainBundle] bundleIdentifier] category:componentName];
-        } else {
-            DDTTYLogger *ttyLogger = [DDTTYLogger sharedInstance];
-            ttyLogger.logFormatter = [[SFSDKFormatter alloc] init];
-            ttyLogger.colorsEnabled = YES;
-            consoleLogger = ttyLogger;
-        }
-        [consoleLoggerDDLog
-            addLogger:consoleLogger
-            withLevel:DDLogLogLevelForSFLogLevel(self.logLevel)];
-        self.consoleLoggers[componentName] = consoleLoggerDDLog;
-
         // Create separate file logger
         self.fileLogger =
             [[SFSDKFileLogger alloc] initWithComponent:componentName];

--- a/libs/SalesforceFileLogger/SalesforceFileLoggerTestApp/ViewController.m
+++ b/libs/SalesforceFileLogger/SalesforceFileLoggerTestApp/ViewController.m
@@ -25,6 +25,7 @@
  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #import "ViewController.h"
+#import "Classes/AppDelegate.h"
 #import <SalesforceFileLogger/SalesforceFileLogger.h>
 
 @interface ViewController ()
@@ -48,9 +49,9 @@
     // Create a new logger instance with OSLog enabled and log some more messages
     SFSDKLogger *osLogTestLogger = [SFSDKLogger sharedInstanceWithComponent:@"OSLog Test"];
     [osLogTestLogger i:[self class] message:@"Info log message with OSLog"];
-    [osLogTestLogger w:[self class] message:@"Warning log message with OSLog"];
-    [osLogTestLogger e:[self class] message:@"Error log message with OSLog"];
-    [osLogTestLogger d:[self class] message:@"Debug log message with OSLog"];
+    [osLogTestLogger w:[AppDelegate class] message:@"Warning log message with OSLog"];
+    [osLogTestLogger e:[NSString class] message:@"Error log message with OSLog"];
+    [osLogTestLogger d:[SFSDKLogger class] message:@"Debug log message with OSLog"];
 }
 
 @end


### PR DESCRIPTION
This is a follow-up to https://github.com/forcedotcom/SalesforceMobileSDK-iOS-Hybrid/pull/271 that takes things a bit further.

The original implementation created an OSLogger per-component, which was being used as the OSLog "category" attribute (since that can only be set when creating a logger).

But components are fairly heavy... if you want your logs going together in the same file, you probably aren't initting a lot of different loggers with different components.

Meanwhile, the log functions also take a class, which was added to the message text in the old TTY logger. This class seems like it might be a useful attribute to display and filter by.

So, the change here is to keep one _file logger_ per component, but create a new _console logger_ per _tag_ (which is a combination of component and class).

This does mean that console loggers are created on-demand rather than via `init`. This applies to the TTY logger mode as well, even though that doesn't really benefit, just for consistency/simplicity.

## Before

<img width="387" height="154" alt="image" src="https://github.com/user-attachments/assets/380b03f2-8e28-4834-9950-36ee411196ff" />

## After

<img width="565" height="161" alt="image" src="https://github.com/user-attachments/assets/44c0a21d-2f23-4bf7-9167-543b20067474" />
