### PR TITLE
Removing consumer key from sample apps

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -16,15 +16,19 @@ jobs:
         include:
           - ios: ^26
             xcode: ^26
+            macos: macos-26
           - ios: ^18
             xcode: ^16
+            macos: macos-15
           - ios: ^17
             xcode: ^16
+            macos: macos-15
     uses: ./.github/workflows/reusable-workflow.yaml
     with:
       lib: ${{ matrix.lib }}
       ios: ${{ matrix.ios }}
       xcode: ${{ matrix.xcode }}
+      macos: ${{ matrix.macos }}
     secrets: inherit
 
   hybrid-samples-nightly:
@@ -36,14 +40,18 @@ jobs:
         include:
           - ios: ^26
             xcode: ^26
+            macos: macos-26
           - ios: ^18
             xcode: ^16
+            macos: macos-15
           - ios: ^17
             xcode: ^16
+            macos: macos-15
     uses: ./.github/workflows/reusable-workflow.yaml
     with:
       lib: ${{ matrix.lib }}
       ios: ${{ matrix.ios }}
       xcode: ${{ matrix.xcode }}
+      macos: ${{ matrix.macos }}
       action: build
     secrets: inherit

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -16,19 +16,15 @@ jobs:
         include:
           - ios: ^26
             xcode: ^26
-            macos: macos-26
           - ios: ^18
             xcode: ^16
-            macos: macos-15
           - ios: ^17
             xcode: ^16
-            macos: macos-15
     uses: ./.github/workflows/reusable-workflow.yaml
     with:
       lib: ${{ matrix.lib }}
       ios: ${{ matrix.ios }}
       xcode: ${{ matrix.xcode }}
-      macos: ${{ matrix.macos }}
     secrets: inherit
 
   hybrid-samples-nightly:
@@ -40,18 +36,14 @@ jobs:
         include:
           - ios: ^26
             xcode: ^26
-            macos: macos-26
           - ios: ^18
             xcode: ^16
-            macos: macos-15
           - ios: ^17
             xcode: ^16
-            macos: macos-15
     uses: ./.github/workflows/reusable-workflow.yaml
     with:
       lib: ${{ matrix.lib }}
       ios: ${{ matrix.ios }}
       xcode: ${{ matrix.xcode }}
-      macos: ${{ matrix.macos }}
       action: build
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -62,13 +62,16 @@ jobs:
         include:
           - ios: ^26
             xcode: ^26
+            macos: macos-26
           - ios: ^18
             xcode: ^16
+            macos: macos-15
     uses: ./.github/workflows/reusable-workflow.yaml
     with:
       lib: ${{ matrix.lib }}
       ios: ${{ matrix.ios }}
       xcode: ${{ matrix.xcode }}
+      macos: ${{ matrix.macos }}
       is_pr: true
     secrets: inherit
 
@@ -82,13 +85,16 @@ jobs:
         include:
           - ios: ^26
             xcode: ^26
+            macos: macos-26
           - ios: ^18
             xcode: ^16
+            macos: macos-15
     uses: ./.github/workflows/reusable-workflow.yaml
     with:
       lib: ${{ matrix.lib }}
       ios: ${{ matrix.ios }}
       xcode: ${{ matrix.xcode }}
+      macos: ${{ matrix.macos }}
       action: build
       is_pr: true
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -62,16 +62,13 @@ jobs:
         include:
           - ios: ^26
             xcode: ^26
-            macos: macos-26
           - ios: ^18
             xcode: ^16
-            macos: macos-15
     uses: ./.github/workflows/reusable-workflow.yaml
     with:
       lib: ${{ matrix.lib }}
       ios: ${{ matrix.ios }}
       xcode: ${{ matrix.xcode }}
-      macos: ${{ matrix.macos }}
       is_pr: true
     secrets: inherit
 
@@ -85,16 +82,13 @@ jobs:
         include:
           - ios: ^26
             xcode: ^26
-            macos: macos-26
           - ios: ^18
             xcode: ^16
-            macos: macos-15
     uses: ./.github/workflows/reusable-workflow.yaml
     with:
       lib: ${{ matrix.lib }}
       ios: ${{ matrix.ios }}
       xcode: ${{ matrix.xcode }}
-      macos: ${{ matrix.macos }}
       action: build
       is_pr: true
     secrets: inherit

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,10 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$SCRIPT_DIR"
 git submodule init
 git submodule sync
-git submodule update --init --recursive
+git submodule update
+
+# Restore bootconfig.json in shared submodule to committed placeholders
+git -C external/shared checkout -- samples/mobilesyncexplorer/bootconfig.json samples/accounteditor/bootconfig.json 2>/dev/null || true
 
 # Create test_credentials.json if needed to avoid build errors
 if [ ! -f "shared/test/test_credentials.json" ]
@@ -20,6 +23,29 @@ then
 fi
 
 # Prepare cordova.js
-cd external/cordova
+pushd "external/cordova"
 npm install
 npm run prepare
+popd
+
+# Substitute env vars if set in bootconfig.json
+BOOTCONFIG_JSON_PATHS=(
+    "external/shared/samples/mobilesyncexplorer/bootconfig.json"
+    "external/shared/samples/accounteditor/bootconfig.json"
+)
+for bootconfig in "${BOOTCONFIG_JSON_PATHS[@]}"; do
+    if [ -n "${MSDK_IOS_REMOTE_ACCESS_CONSUMER_KEY:-}" ]; then
+        gsed -i "s|__CONSUMER_KEY__|${MSDK_IOS_REMOTE_ACCESS_CONSUMER_KEY}|g" "$bootconfig"
+    fi
+    if [ -n "${MSDK_IOS_REMOTE_ACCESS_CALLBACK_URL:-}" ]; then
+        gsed -i "s|__REDIRECT_URI__|${MSDK_IOS_REMOTE_ACCESS_CALLBACK_URL}|g" "$bootconfig"
+    fi
+done
+
+if [ -z "${MSDK_IOS_REMOTE_ACCESS_CONSUMER_KEY:-}" ] || [ -z "${MSDK_IOS_REMOTE_ACCESS_CALLBACK_URL:-}" ]; then
+    echo ""
+    echo "Note: MSDK_IOS_REMOTE_ACCESS_CONSUMER_KEY and/or MSDK_IOS_REMOTE_ACCESS_CALLBACK_URL are not set."
+    echo "To run the sample applications, define these environment variables or ensure bootconfig.json"
+    echo "files have remoteAccessConsumerKey and oauthRedirectURI set."
+    echo ""
+fi


### PR DESCRIPTION
Consumer key and call back url are set on bootconfig.json for the sample apps using environment variables (*) if defined

(*) MSDK_IOS_REMOTE_ACCESS_CONSUMER_KEY and MSDK_IOS_REMOTE_ACCESS_CALLBACK_URL

**Merge only after**
- https://github.com/forcedotcom/SalesforceMobileSDK-Shared/pull/539 is merged
- https://github.com/forcedotcom/SalesforceMobileSDK-iOS/pull/3981 is merged
- shared submodule is updated
- SalesforceMobileSDK-iOS submodule is updated