### PR TITLE
Update nightly schedule to Tue/Thu at 9:30 PM PT and fix security issues

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -2,9 +2,12 @@ name: Nightly Tests
 
 on:
   schedule:
-    - cron: "0 5 * * 4"  # cron is UTC, this translates to 10 PM PST Wednesday.
+    - cron: "30 5 * * 3,5"  # cron is UTC; 9:30 PM PT Tue/Thu.
   # This lets us trigger the workflow from a browser.
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   ios-nightly:
@@ -23,7 +26,12 @@ jobs:
       lib: ${{ matrix.lib }}
       ios: ${{ matrix.ios }}
       xcode: ${{ matrix.xcode }}
-    secrets: inherit
+    permissions:
+      contents: read
+      pull-requests: write
+    secrets:
+      TEST_CREDENTIALS: ${{ secrets.TEST_CREDENTIALS }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   hybrid-samples-nightly:
     strategy:
@@ -41,4 +49,5 @@ jobs:
       app: ${{ matrix.app }}
       ios: ${{ matrix.ios }}
       xcode: ${{ matrix.xcode }}
-    secrets: inherit
+    permissions:
+      contents: read

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,17 +1,25 @@
 name: Pull Request
 
 on:
-  pull_request_target:
+  # pull_request_target is required for fork PRs to receive secrets.
+  # Mitigated by per-job Member Check (see "Check Write Permission" / "Validate Write Permission").
+  pull_request_target:  # zizmor: ignore[dangerous-triggers]
     branches: [dev, master]
+
+permissions:
+  contents: read
 
 jobs:
   static-analysis:
     runs-on: macos-latest
+    permissions:
+      contents: read
+      pull-requests: write
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/.github/DangerFiles/Gemfile
     steps:
       - name: Check Write Permission
-        uses: octokit/request-action@v2.x
+        uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d  # v2.4.0
         id: check_permissions
         with:
           route: GET /repos/${{ github.repository }}/collaborators/${{ github.triggering_actor }}/permission
@@ -29,8 +37,9 @@ jobs:
             exit 1
           fi
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
+          persist-credentials: false
           # We need a sufficient depth or Danger will occasionally run into issues checking which files were modified.
           fetch-depth: 100
           # This is dangerous without the member check
@@ -43,7 +52,7 @@ jobs:
         run:
           xcodebuild analyze -workspace SalesforceMobileSDK-Hybrid.xcworkspace -scheme MobileSync -sdk 'iphonesimulator' \
           CLANG_ANALYZER_OUTPUT=plist-html CLANG_ANALYZER_OUTPUT_DIR=./clangReport RUN_CLANG_STATIC_ANALYZER=YES
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f  # v1.310.0
         with:
           ruby-version: '3.3'
           bundler-cache: true
@@ -64,7 +73,12 @@ jobs:
       lib: ${{ matrix.lib }}
       ios: ${{ matrix.ios }}
       is_pr: true
-    secrets: inherit
+    permissions:
+      contents: read
+      pull-requests: write
+    secrets:
+      TEST_CREDENTIALS: ${{ secrets.TEST_CREDENTIALS }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   hybrid-samples-pr:
     needs: [static-analysis]
@@ -76,4 +90,5 @@ jobs:
     with:
       app: ${{ matrix.app }}
       is_pr: true
-    secrets: inherit
+    permissions:
+      contents: read

--- a/.github/workflows/reusable-build-workflow.yaml
+++ b/.github/workflows/reusable-build-workflow.yaml
@@ -20,24 +20,30 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   build-ios:
     runs-on: ${{ inputs.macos }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ ! inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.head_ref }}
       - name: Install Dependencies
         run: ./install.sh
       - name: Install iOS 17 runtime if needed
         if: ${{ inputs.ios == '^17' }}
         run: xcodes runtimes install "iOS 17.5"
-      - uses: mxcl/xcodebuild@v3
+      - uses: mxcl/xcodebuild@d3ee9b419c1be9a988086c58fe0988f32d99cfc5  # v3.6.0
+        id: build
         with:
           xcode: ${{ inputs.xcode }}
           platform: iOS
@@ -46,3 +52,13 @@ jobs:
           scheme: ${{ inputs.app }}
           action: build
           verbosity: xcbeautify
+      - name: Archive build logs on failure
+        if: failure() && steps.build.outcome == 'failure'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: xcode-build-logs-${{ inputs.app }}-ios${{ inputs.ios }}
+          path: |
+            ~/Library/Developer/Xcode/DerivedData/**/Logs/Build/*.xcactivitylog
+            ~/Library/Logs/DiagnosticReports/**
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/reusable-test-workflow.yaml
+++ b/.github/workflows/reusable-test-workflow.yaml
@@ -19,18 +19,29 @@ on:
       is_pr:
         type: boolean
         default: false
+    secrets:
+      TEST_CREDENTIALS:
+        required: true
+      CODECOV_TOKEN:
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   test-ios:
     runs-on: ${{ inputs.macos }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ ! inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.head_ref }}
       - name: Install Dependencies
         env:
@@ -38,7 +49,7 @@ jobs:
         run: |
           ./install.sh
           echo $TEST_CREDENTIALS > ./shared/test/test_credentials.json
-      - uses: mxcl/xcodebuild@v3
+      - uses: mxcl/xcodebuild@d3ee9b419c1be9a988086c58fe0988f32d99cfc5  # v3.6.0
         id: xcodebuild
         with:
           xcode: ${{ inputs.xcode }}
@@ -49,13 +60,25 @@ jobs:
           action: test
           code-coverage: true
           verbosity: xcbeautify
+      - name: Archive xcodebuild logs on build failure
+        if: failure() && steps.xcodebuild.outcome == 'failure'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: xcodebuild-logs-${{ inputs.lib }}-ios${{ inputs.ios }}
+          path: |
+            ~/Library/Developer/Xcode/DerivedData/**/Logs/Build/*.xcactivitylog
+          if-no-files-found: ignore
+          retention-days: 14
       - name: Parse test results
         if: success() || failure()
+        env:
+          LIB: ${{ inputs.lib }}
+          IOS: ${{ inputs.ios }}
         run: |
           brew install xcresultparser
-          xcresultparser -o junit test.xcresult > test-results-${{ inputs.lib }}-ios${{ inputs.ios }}.xml
+          xcresultparser -o junit test.xcresult > "test-results-${LIB}-ios${IOS}.xml"
       - name: Test Report
-        uses: mikepenz/action-junit-report@v6
+        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d  # v6.4.1
         if: success() || failure()
         with:
           check_name: ${{ inputs.lib }} iOS ${{ inputs.ios }} Test Results
@@ -67,7 +90,7 @@ jobs:
           comment: true
           job_summary: ${{ steps.xcodebuild.outcome == 'failure' }}
           report_paths: 'test-results-${{ inputs.lib }}-ios${{ inputs.ios }}.xml'
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238  # v4.6.0
         if: success() || failure()
         with:
           flags: ${{ inputs.lib }}
@@ -75,7 +98,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload test results artifact
         if: success() || failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: test-results-${{ inputs.lib }}-ios${{ inputs.ios }}
           path: test-results-${{ inputs.lib }}-ios${{ inputs.ios }}.xml


### PR DESCRIPTION
## Summary

Implements [W-22712082 — Cleanup CI for all Repos](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002b3viMYAQ/view).

**Schedule change**: Nightly tests now run **Tue/Thu at 9:30 PM PT** (`30 5 * * 3,5` UTC), up from Wed-only. Catches regressions twice a week instead of once. Alternates with the ReactNative nightly's Mon/Wed/Fri 9:30 PM slot.

**Security hardening**: All workflows updated to follow the [GitHub Actions injection-prevention best practices](https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/):

- **All third-party actions SHA-pinned** with the resolved tag in a comment.
- **Top-level `permissions:` block** added to every workflow: `contents: read` baseline, `pull-requests: write` for the test reusable (it uses `mikepenz/action-junit-report` with `comment: true`).
- **`secrets: inherit` replaced with explicit secret pass-through**; reusable test workflow declares `TEST_CREDENTIALS` and `CODECOV_TOKEN` in `on: workflow_call: secrets:`.
- **All `${{ ... }}` shell interpolation** in `run:` blocks refactored to `env:` variables with quoted shell expansions (only the `Parse test results` step in the reusable test workflow had any).
- **`pull_request_target`** retained with `# zizmor: ignore[dangerous-triggers]` and inline comment documenting the Member Check mitigation.
- **`actions/checkout` steps** set `with: persist-credentials: false`.
- **xcodebuild logs archived on build failure** for diagnostic purposes.

After this change, `zizmor --offline` reports 0 High-confidence findings across all four CI workflows.

## Test plan

- [x] Verified locally with `python3 yaml.safe_load`, `actionlint -shellcheck=`, `zizmor --offline`. All clean.
- [x] CI verification: opened test PR on personal fork (`brandonpage/SalesforceMobileSDK-iOS-Hybrid#2`) targeting the same `cleanup-ci-w22712082` branch as this PR. The test PR triggers the new workflows against a real source change in `SalesforceFileLogger`. **No regressions observed** — see linked PR for run details.
- [ ] Reviewer to confirm the `permissions:` blocks match the team's expected privilege levels for each workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
