### PR TITLE
W-23212499: Fix iOS 18 / Xcode 16 CI jobs broken by macos-latest → macOS 26 migration

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -21,11 +21,13 @@ jobs:
             xcode: ^26
           - ios: ^18
             xcode: ^16
+            macos: macos-15
     uses: ./.github/workflows/reusable-test-workflow.yaml
     with:
       lib: ${{ matrix.lib }}
       ios: ${{ matrix.ios }}
       xcode: ${{ matrix.xcode }}
+      macos: ${{ matrix.macos }}
     permissions:
       contents: read
       pull-requests: write
@@ -44,10 +46,12 @@ jobs:
             xcode: ^26
           - ios: ^18
             xcode: ^16
+            macos: macos-15
     uses: ./.github/workflows/reusable-build-workflow.yaml
     with:
       app: ${{ matrix.app }}
       ios: ${{ matrix.ios }}
       xcode: ${{ matrix.xcode }}
+      macos: ${{ matrix.macos }}
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- GitHub migrated `macos-latest` to macOS 26 on June 15, 2026. macOS 26 ships only Xcode 26 and iOS 26 simulators — Xcode 16 and iOS 18 simulators are not available on it.
- The `ios: ^18` / `xcode: ^16` matrix entries in both `ios-nightly` and `hybrid-samples-nightly` jobs were failing because they ran on `macos-latest` (now macOS 26).
- This PR pins those entries to `macos-15` by adding `macos: macos-15` to each affected `include` block and passing `macos: ${{ matrix.macos }}` in the `with:` block of each reusable workflow call.
- The `ios: ^26` / `xcode: ^26` entries are left unchanged — they correctly use the default `macos-latest` (macOS 26).
- The reusable workflow files (`reusable-test-workflow.yaml`, `reusable-build-workflow.yaml`) are not modified; they already accept a `macos` input with `default: macos-latest`.

## Test plan

- [ ] Verify nightly workflow runs successfully for both iOS 18 (macos-15) and iOS 26 (macos-latest) matrix entries
- [ ] Confirm `ios-nightly` and `hybrid-samples-nightly` jobs both complete without runner-not-found errors