### PR TITLE
Moving to SQLCipher 4.17.0

### DIFF
--- a/hybrid/SampleApps/AccountEditor/AccountEditor.xcodeproj/project.pbxproj
+++ b/hybrid/SampleApps/AccountEditor/AccountEditor.xcodeproj/project.pbxproj
@@ -1339,7 +1339,7 @@
 			repositoryURL = "https://github.com/sqlcipher/SQLCipher.swift";
 			requirement = {
 				kind = exactVersion;
-				version = 4.16.0;
+				version = 4.17.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/hybrid/SampleApps/MobileSyncExplorerHybrid/MobileSyncExplorerHybrid.xcodeproj/project.pbxproj
+++ b/hybrid/SampleApps/MobileSyncExplorerHybrid/MobileSyncExplorerHybrid.xcodeproj/project.pbxproj
@@ -1339,7 +1339,7 @@
 			repositoryURL = "https://github.com/sqlcipher/SQLCipher.swift";
 			requirement = {
 				kind = exactVersion;
-				version = 4.16.0;
+				version = 4.17.0;
 			};
 		};
 		693387C62E83320100F667A7 /* XCRemoteSwiftPackageReference "fmdb" */ = {


### PR DESCRIPTION
## Summary

- Advances `external/SalesforceMobileSDK-iOS` submodule to the sqlcipher-4.17.0 branch
- Updates SQLCipher SPM exact version to 4.17.0 in `AccountEditor.xcodeproj`
- Updates SQLCipher SPM exact version to 4.17.0 in `MobileSyncExplorerHybrid.xcodeproj`

## Release notes
https://www.zetetic.net/blog/2026/07/08/sqlcipher-4.17.0-release/

## GUS
W-23369878

## Related PRs
- forcedotcom/SalesforceMobileSDK-iOS#4096
- forcedotcom/SalesforceMobileSDK-iOS-Specs#70

## Test plan
- [ ] CI: SalesforceHybridSDK tests pass
- [ ] AccountEditor sample app builds
- [ ] MobileSyncExplorerHybrid sample app builds