### PR TITLE
Add #GUSINFO to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
 # Comment line immediately above ownership line is reserved for related gus information. Please be careful while editing.
+#GUSINFO:Mobile SDK,Mobile SDK - iOS
 #ECCN:Open Source


### PR DESCRIPTION
Adds the required `#GUSINFO:Mobile SDK,Mobile SDK - iOS` line to CODEOWNERS to comply with FY27 OSPO code ownership requirements.

This repo was not covered by the initial CODEOWNERS compliance sweep. The product tag is verified against GUS (registered `ADM_Product_Tag__c` owned by the `Mobile SDK` scrum team).

*This response was generated by an AI agent on behalf of @JohnsonEricAtSalesforce.*